### PR TITLE
fix:edit VaunchFile description

### DIFF
--- a/src/models/VaunchLink.ts
+++ b/src/models/VaunchLink.ts
@@ -23,8 +23,8 @@ export class VaunchLink extends VaunchUrlFile {
   }
 
   getDescription(): string {
-    if (this.description) return `Navigate to: ${this.description}`;
-    return "Naviagte to: " + this.trimString(this.getCorrectURL());
+    if (this.description) return this.description;
+    return "Navigate to: " + this.trimString(this.getCorrectURL());
   }
 
   execute(args:string[]): void {


### PR DESCRIPTION
fix navigate typo. Remove "Navigate to:" when the file has a
description