### PR TITLE
fix:command file add if on execute

### DIFF
--- a/src/components/VaunchGuiCommand.vue
+++ b/src/components/VaunchGuiCommand.vue
@@ -22,7 +22,9 @@ export default defineComponent({
   methods: {
     execute(file:VaunchCommand, args:string[]) {
       file.execute(args);
-      (this.$refs.commandInputBox as HTMLInputElement).value = "";
+      if (file.hasArgs) {
+        (this.$refs.commandInputBox as HTMLInputElement).value = "";
+      }
     },
     handleClick(file:VaunchCommand, args:string[]) {
       if (file.hasArgs) {


### PR DESCRIPTION
always tried to clear its commandinputBox, even if it didn't have one
now it will check if it has args, and therefore an inputbox