### PR TITLE
feat:can go directly to URLs

### DIFF
--- a/src/Vaunch.vue
+++ b/src/Vaunch.vue
@@ -12,6 +12,7 @@ import { useFuzzyStore } from "./stores/fuzzy";
 import VaunchFuzzy from "./components/VaunchFuzzy.vue";
 import VaunchGuiCommands from "./components/VaunchGuiCommands.vue";
 import VaunchMan from "./components/VaunchMan.vue";
+import { VaunchLink } from "./models/VaunchLink";
 
 export default defineComponent({
   name: "Vaunch",
@@ -74,10 +75,16 @@ export default defineComponent({
       }
 
       // If a fuzzy file has been chosen, let's execute that
-      if (this.fuzzyFiles.items.length > 0) {
+      if (this.fuzzyFiles.items.length > 0 && this.config.fuzzy) {
         let response = this.fuzzyFiles.items[this.fuzzyFiles.index].execute(commandArgs)
         return this.passInput(response);
       }
+
+      // If the input is a valid URL, navigate to it. Create a temporary VaunchLink with the operator and commandArgs
+      // then attempt to run the file. If it isn't a valid URL nothing will happen, if it is, the url is navigated to.
+      let urlValue:string = [operator, ...commandArgs].join(' ');
+      let tempLink:VaunchLink = new VaunchLink("temp", urlValue);
+      tempLink.execute([]);
 
       // Failing everything else, pass the input to the default file
       // Push the first word back into commandArgs, as there is no operator

--- a/src/models/VaunchLink.ts
+++ b/src/models/VaunchLink.ts
@@ -6,7 +6,7 @@ export class VaunchLink extends VaunchUrlFile {
   extension:string = ".lnk"
   filetype:string = "VaunchLink";
 
-  constructor(name:string, content:string, parent:VaunchFolder, icon:string = "file",
+  constructor(name:string, content:string, parent:VaunchFolder|undefined=undefined, icon:string = "file",
    iconClass:string = "solid", hits:number = 0, description:string="") {
     if (!name.endsWith('.lnk')) {
       name = name+".lnk"

--- a/src/models/VaunchQuery.ts
+++ b/src/models/VaunchQuery.ts
@@ -19,10 +19,7 @@ export class VaunchQuery extends VaunchUrlFile {
 
   getDescription(): string {
     if (this.description) return `${this.prefix}: ${this.description}`;
-    let host:string|undefined = this.createUrl()?.origin
-    if (host) {
-      return `Search: ${this.prefix}: ${this.content}`;
-    } else return `${this.prefix}: ${host}`;
+    return `Search: ${this.prefix}: ${this.content}`;
   }
 
   getNames():string[] {

--- a/src/models/VaunchUrlFile.ts
+++ b/src/models/VaunchUrlFile.ts
@@ -3,14 +3,14 @@ import type { VaunchFolder } from "./VaunchFolder";
 
 export abstract class VaunchUrlFile extends VaunchFile {
 
-  parent:VaunchFolder;
+  parent:VaunchFolder|undefined;
   filetype:string = "VaunchUrlFile";
 
-  constructor(name:string, parent:VaunchFolder, icon:string, iconClass:string, hits:number = 0, description:string="") {
+  constructor(name:string, parent:VaunchFolder|undefined, icon:string, iconClass:string, hits:number = 0, description:string="") {
     super(name, icon, iconClass, hits);
-    this.parent = parent;
     this.description = description
-    if (this.parent) {
+    if (parent) {
+      this.parent = parent;
       this.aliases.push(`${this.parent.name}/${this.fileName}`);
     }
   }
@@ -23,18 +23,30 @@ export abstract class VaunchUrlFile extends VaunchFile {
 
   protected createUrl(url:string = this.content): URL|undefined {
     try {
-      let urlString:string = this.prependHttps(url);
-      return new URL(urlString);
+      // If passed url starts with http/https already, attempt to return it as a URL
+      // otherwise prepend https:// to it.
+      let httpPrefixedTest:RegExp = /^https?:\/\//g
+      if (httpPrefixedTest.test(url)) {
+        return new URL(url);
+      } else url = this.prependHttps(url);
+      
+      // Now with https:// prepended, run an additional URL test against the string
+      let fullUrlTest:RegExp = /^(http(s)?:\/\/.)?(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)$/g
+      if (fullUrlTest.test(url)) {
+        return new URL(url);
+      } else return undefined;
     } catch (e) {
       return undefined
     }
   }
 
   protected getParentName(titleCase:boolean=false):string {
-    if (titleCase) {
-      return this.parent.titleCase();
-    }
-    return this.parent.name;
+    if (this.parent) {
+      if (titleCase) {
+        return this.parent.titleCase();
+      }
+      return this.parent.name;
+    } else return "";
   }
 
   getCorrectURL(): string {


### PR DESCRIPTION
fix:fuzzy fiels only executes with fuzzy on

Enerting a URL into the command input will navigate there.
Makes a temp VaunchLink to test the URL
VaunchURLFile createUrl has extra conditions to returns a URL
Modified VaunchQuery getDescription to always return this.content if
no description is set, as new URL checking failed with ${}