### PR TITLE
feat:sorting sets position to sensible numbers

### DIFF
--- a/src/models/VaunchFolder.ts
+++ b/src/models/VaunchFolder.ts
@@ -58,6 +58,14 @@ export class VaunchFolder {
     return final;
   }
 
+  organiseFiles(semiSortedFiles:VaunchFile[]) {
+    // To br ran on semi-sorted arrays, with where items are sorted,
+    // but positions may not be in sequence with each other
+    for( let [index, file] of semiSortedFiles.entries() ) {
+      file.position = index+1;
+    }
+  }
+
   setFilePosition(fileName:string, position:number):boolean {
     // Set the folder's position
     let currentFile:VaunchFile|undefined = this.getFile(fileName);
@@ -70,6 +78,9 @@ export class VaunchFolder {
       this.fixOrder(fileName, currentFile.position, positionGoingDown);
 
     } else return false
+    // After setting the position, set each folder's position to a 'sensible' order
+    let sortOfSorted = this.sortFiles();
+    this.organiseFiles(sortOfSorted);
     return true
   }
 

--- a/src/stores/folder.ts
+++ b/src/stores/folder.ts
@@ -79,6 +79,13 @@ export const useFolderStore: StoreDefinition = defineStore({
       let final = [...sortable, ...unsorted]
       return final;
     },
+    organisePosition(semiSortedFolders:VaunchFolder[]) {
+      // To br ran on semi-sorted arrays, with where items are sorted,
+      // but positions may not be in sequence with each other
+      for( let [index, folder] of semiSortedFolders.entries() ) {
+        folder.position = index+1;
+      }
+    },
     setPosition(folderName:string, position:number):boolean {
       // Set the folder's position
       let currentFolder:VaunchFolder = this.getFolderByName(folderName);
@@ -86,10 +93,13 @@ export const useFolderStore: StoreDefinition = defineStore({
         let positionGoingDown = (position > currentFolder.position && currentFolder.position != -1);
         currentFolder.position = position;
         if (position == -1) return true;
-
         this.fixOrder(folderName, currentFolder.position, positionGoingDown)
-
       } else return false;
+
+      // After setting the position, set each folder's position to a 'sensible' order
+      let sortOfSorted = this.sortedItems();
+      this.organisePosition(sortOfSorted);
+
       return true;
     },
     fixOrder(foldername:string, position:number, movingDown:boolean):void {


### PR DESCRIPTION
after setting a file/folder position all files in that folder/all
folders will have their position set to their actual position.
So setting a position folder to '999' etc, where there are only
10 folders will set that folder's position to 10 after all sorting
is done