### PR TITLE
fix:replace hasArgs property with method

### DIFF
--- a/src/components/VaunchGuiCommand.vue
+++ b/src/components/VaunchGuiCommand.vue
@@ -7,20 +7,21 @@ import type { VaunchCommand } from "@/models/VaunchCommand";
 const config = useConfigStore();
 const commandInput = "";
 
-defineProps(["file", "parentFolderName", "isFuzzy"]);
+const props = defineProps(["file", "parentFolderName", "isFuzzy"]);
 
 const commandInputBox = ref();
+const hasArgs = props.file.hasArgs();
 
 const execute = (file:VaunchCommand, args:string[]) => {
   file.execute(args);
   // Clear the input for this command after executing
-  if (file.hasArgs) {
+  if (hasArgs) {
     (commandInputBox.value as HTMLInputElement).value = "";
   }
 }
 
 const handleClick = (file: VaunchCommand, args: string[]) => {
-  if (file.hasArgs) {
+  if (hasArgs) {
     (commandInputBox.value as HTMLInputElement).focus();
   } else {
     execute(file, args);
@@ -90,7 +91,7 @@ const handleClick = (file: VaunchCommand, args: string[]) => {
       <i class="fa-solid fa-chevron-right file-icon"></i>
       <span class="command-name">{{ file.titleCase() }}</span>
       <input
-        v-if="file.hasArgs"
+        v-if="hasArgs"
         class="command-input"
         @keydown.enter.prevent="execute(file, commandInput.split(' '))"
         v-model="commandInput"

--- a/src/models/VaunchCommand.ts
+++ b/src/models/VaunchCommand.ts
@@ -3,7 +3,6 @@ import { VaunchManual, type Example, type Parameter } from "./VaunchManual";
 import { ResponseType, type VaunchResponse } from "./VaunchResponse";
 
 export abstract class VaunchCommand extends VaunchFile {
-  hasArgs = true;
   filetype = "VaunchCommand";
   manual: VaunchManual;
 
@@ -15,6 +14,10 @@ export abstract class VaunchCommand extends VaunchFile {
   ) {
     super(fileName);
     this.manual = new VaunchManual(longDescription, parameter, examples);
+  }
+
+  hasArgs():boolean {
+    return this.manual.parameters.length > 0;
   }
 
   execute(args: string[]): VaunchResponse {

--- a/src/models/commands/config/VaunchHelp.ts
+++ b/src/models/commands/config/VaunchHelp.ts
@@ -4,7 +4,6 @@ import { ResponseType, type VaunchResponse } from "@/models/VaunchResponse";
 import { useSessionStore } from "@/stores/sessionState";
 
 export class VaunchHelp extends VaunchCommand {
-  hasArgs = false;
   constructor() {
     const longDescription: string[] = [
       "Shows this help page. Passing an argument will automatically search for the command.",

--- a/src/models/commands/config/VaunchToggleCase.ts
+++ b/src/models/commands/config/VaunchToggleCase.ts
@@ -4,7 +4,6 @@ import { ResponseType, type VaunchResponse } from "@/models/VaunchResponse";
 import { useConfigStore } from "@/stores/config";
 
 export class VaunchToggleCase extends VaunchCommand {
-  hasArgs = false;
   constructor() {
     const longDescription: string[] = [
       "Toggles if the names of files/folders are displayed in Title Case or not.",

--- a/src/models/commands/config/VaunchToggleCommands.ts
+++ b/src/models/commands/config/VaunchToggleCommands.ts
@@ -4,7 +4,6 @@ import { ResponseType, type VaunchResponse } from "@/models/VaunchResponse";
 import { useConfigStore } from "@/stores/config";
 
 export class VaunchToggleCommands extends VaunchCommand {
-  hasArgs = false;
   constructor() {
     const longDescription: string[] = [
       `Toggles if the command window is shows. The command window lists all available commands, and

--- a/src/models/commands/config/VaunchToggleFuzzy.ts
+++ b/src/models/commands/config/VaunchToggleFuzzy.ts
@@ -4,7 +4,6 @@ import { ResponseType, type VaunchResponse } from "@/models/VaunchResponse";
 import { useConfigStore } from "@/stores/config";
 
 export class VaunchToggleFuzzy extends VaunchCommand {
-  hasArgs = false;
   constructor() {
     const longDescription: string[] = [
       `Toggles if fuzzy searching is enabled. When enabled, typing in the command box will display

--- a/src/models/commands/config/VaunchToggleGui.ts
+++ b/src/models/commands/config/VaunchToggleGui.ts
@@ -4,7 +4,6 @@ import { ResponseType, type VaunchResponse } from "@/models/VaunchResponse";
 import { useConfigStore } from "@/stores/config";
 
 export class VaunchToggleGui extends VaunchCommand {
-  hasArgs = false;
   constructor() {
     const longDescription: string[] = [
       "Toggles if the Folders/Commands section of Vaunch will be visible.",


### PR DESCRIPTION
Rather than having a boolean to tell if a command has arguments, use
the file's documentation as reference. If the manual as any properties
the file has arguments