### PR TITLE
refacor:remove set-input/pass-input emits

### DIFF
--- a/src/VaunchApp.vue
+++ b/src/VaunchApp.vue
@@ -169,7 +169,7 @@ const handleResponse = (response: VaunchResponse) => {
 
 const passInput = (input: string | void) => {
   let newInput: string = input ? input : "";
-  (vaunchInput.value as typeof VaunchInput).setInput(newInput);
+  sessionConfig.vaunchInput = newInput;
 }
 
 const updateFuzzyIndex = (increment: boolean) => {
@@ -281,7 +281,6 @@ main {
         v-if="fuzzyFiles.items.length > 0 && config.fuzzy"
         :fuzzy-matches="fuzzyFiles.items"
         :current-index="fuzzyFiles.index"
-        v-on:set-input="passInput"
       />
 
       <div v-if="config.showGUI" id="commands-folders-container">
@@ -296,7 +295,6 @@ main {
           <VaunchGuiFolder
             v-for="folder in folders.sortedItems()"
             :key="folder.name"
-            v-on:set-input="passInput"
             v-on:show-file-option="showFileOption"
             :folder="folder"
           />
@@ -306,7 +304,6 @@ main {
 
     <VaunchMan v-if="sessionConfig.showHelp" :commands="commands" />
     <VaunchFileOption v-if="data.showOptions" v-on:dismiss-self="data.showOptions = false;" 
-    v-on:set-input="passInput"
     v-on:send-response="handleResponse"
     :file="data.optionFile" :x-pos="data.optionX" :y-pos="data.optionY"/>
   </main>

--- a/src/components/VaunchFileOption.vue
+++ b/src/components/VaunchFileOption.vue
@@ -5,12 +5,15 @@ import { ref, onMounted, onUpdated, reactive } from 'vue'
 import VaunchFileEdit from './VaunchFileEdit.vue'
 import VaunchConfirm from './VaunchConfirm.vue'
 import { useConfigStore } from '@/stores/config';
+import { useSessionStore } from '@/stores/sessionState';
+import { focusVaunchInput } from '@/utilities/inputUtils';
 
 const props = defineProps(['file', 'xPos', 'yPos'])
-const emit = defineEmits(["dismissSelf", "set-input", "sendResponse"]);
+const emit = defineEmits(["dismissSelf", "sendResponse"]);
 const option = ref()
 const optionContainer = ref()
 const config = useConfigStore();
+const sessionConfig = useSessionStore();
 
 const state = reactive({
   showEdit:false,
@@ -45,7 +48,8 @@ const deleteFile = () => {
 const executeFile = (args:string[]) => {
   let response: VaunchResponse = props.file.execute(args);
   if (response.type == ResponseType.UpdateInput) {
-    emit("set-input", response.message);
+    sessionConfig.vaunchInput = response.message;
+    focusVaunchInput()
   }
   hideEditWindow();
 }

--- a/src/components/VaunchFuzzy.vue
+++ b/src/components/VaunchFuzzy.vue
@@ -1,16 +1,14 @@
 <script setup lang="ts">
 import { useConfigStore } from "@/stores/config";
+import { useSessionStore } from "@/stores/sessionState";
 import { ref, watch } from "vue";
 import VaunchGuiFile from "./VaunchGuiFile.vue";
 
 const props = defineProps(["fuzzyMatches", "currentIndex"])
-const emit = defineEmits(["set-input"])
 const config = useConfigStore();
 const files = ref();
 
 const getCurrentIndex = () => props.currentIndex;
-
-const passInput = (input:string) => emit("set-input", input);
 
 watch(getCurrentIndex, (newIndex:number) => {
   let fileElement = files.value as typeof VaunchGuiFile[];
@@ -87,7 +85,6 @@ watch(getCurrentIndex, (newIndex:number) => {
       <VaunchGuiFile
         ref="files"
         :class="{ highlight: file === fuzzyMatches[currentIndex] }"
-        v-on:set-input="passInput"
         v-for="file in fuzzyMatches"
         :key="file.fileName"
         :file="file"

--- a/src/components/VaunchGuiFile.vue
+++ b/src/components/VaunchGuiFile.vue
@@ -3,15 +3,19 @@ import { useConfigStore } from "@/stores/config";
 import VaunchTooltip from "./VaunchTooltip.vue";
 import type { VaunchUrlFile } from "@/models/VaunchUrlFile";
 import { ResponseType, type VaunchResponse } from "@/models/VaunchResponse";
+import { useSessionStore } from "@/stores/sessionState";
+import { focusVaunchInput } from "@/utilities/inputUtils";
 
 const config = useConfigStore();
+const sessionConfig = useSessionStore();
 const props = defineProps(["file","isFuzzy"])
-const emit = defineEmits(["set-input", "showFileOption"]);
+const emit = defineEmits(["showFileOption"]);
 
 const execute = (file: VaunchUrlFile, args: string[]) => {
   let response: VaunchResponse = file.execute(args);
   if (response.type == ResponseType.UpdateInput) {
-    emit("set-input", response.message);
+    sessionConfig.vaunchInput = response.message;
+    focusVaunchInput();
   }
 }
 

--- a/src/components/VaunchGuiFolder.vue
+++ b/src/components/VaunchGuiFolder.vue
@@ -7,11 +7,7 @@ import type { VaunchUrlFile } from "@/models/VaunchUrlFile";
 const config = useConfigStore();
 
 defineProps(["folder"]);
-const emit = defineEmits(["set-input", "showFileOption"]);
-
-const passInput = (input:string) => {
-  emit("set-input", input);
-}
+const emit = defineEmits(["showFileOption"]);
 
 const passFileOption = (file: VaunchUrlFile, xPos:number, yPos:number) => {
   emit("showFileOption", file, xPos, yPos)
@@ -58,7 +54,6 @@ const passFileOption = (file: VaunchUrlFile, xPos:number, yPos:number) => {
     </span>
     <div v-if="folder.getFiles().length > 0" class="file-container">
       <VaunchGuiFile
-        v-on:set-input="passInput"
         v-on:show-file-option="passFileOption"
         v-for="file in folder.sortFiles()"
         :file="file"

--- a/src/components/VaunchInput.vue
+++ b/src/components/VaunchInput.vue
@@ -26,7 +26,7 @@ onMounted(() => {
 });
 
 
-const getInput = () => data.vaunchInput;
+const getInput = () => sessionConfig.vaunchInput;
 watch(getInput, (val: string) => {
   // If traversing history, ignore this input. Otherwise continue on and reset the history index
   if (data.traversingHistory) {
@@ -126,23 +126,15 @@ watch(getInput, (val: string) => {
   if (file) emit("set-input-icon", file);
 })
 
-const setInput = (input: string) => {
-  data.vaunchInput = input;
-  (inputBox.value as HTMLInputElement).focus();
-}
-defineExpose({
-  setInput
-});
-
 const complete = () => {
   // Only complete if there is something to complete
-  if (data.autocomplete.length > data.vaunchInput.length) {
-    data.vaunchInput = data.autocomplete + (data.isAutocompletePartial || data.autocomplete.endsWith("/") ? "" : " ");
+  if (data.autocomplete.length > sessionConfig.vaunchInput.length) {
+    sessionConfig.vaunchInput = data.autocomplete + (data.isAutocompletePartial || data.autocomplete.endsWith("/") ? "" : " ");
   }
 }
 
 const sendCommand = (newTab = false) => {
-  let trimmedInput = data.vaunchInput.trim();
+  let trimmedInput = sessionConfig.vaunchInput.trim();
   emit("command", trimmedInput.split(" "), newTab);
 }
 
@@ -175,17 +167,17 @@ const downKeyAction = () => {
   let currentHistoryEntry: string =
     sessionConfig.history[sessionConfig.historyIndex];
   if (
-    (data.vaunchInput == "" || data.vaunchInput == currentHistoryEntry) &&
+    (sessionConfig.vaunchInput == "" || sessionConfig.vaunchInput == currentHistoryEntry) &&
     sessionConfig.historyIndex != -1
   ) {
     sessionConfig.historyIndex--;
     data.traversingHistory = true;
     if (sessionConfig.historyIndex == -1) {
-      data.vaunchInput = "";
+      sessionConfig.vaunchInput = "";
     } else {
       let wantedEntry =
         sessionConfig.history[sessionConfig.historyIndex];
-      data.vaunchInput = wantedEntry;
+      sessionConfig.vaunchInput = wantedEntry;
     }
   }
   emit("fuzzyIncrement", true);
@@ -196,14 +188,14 @@ const upKeyAction = () => {
   let currentHistoryEntry: string =
     sessionConfig.history[sessionConfig.historyIndex];
   if (
-    (data.vaunchInput == "" || data.vaunchInput == currentHistoryEntry) &&
+    (sessionConfig.vaunchInput == "" || sessionConfig.vaunchInput == currentHistoryEntry) &&
     sessionConfig.historyIndex < sessionConfig.history.length - 1
   ) {
     sessionConfig.historyIndex++;
     data.traversingHistory = true;
     let wantedEntry =
       sessionConfig.history[sessionConfig.historyIndex];
-    data.vaunchInput = wantedEntry;
+    sessionConfig.vaunchInput = wantedEntry;
   }
   emit("fuzzyIncrement", false);
 }
@@ -306,13 +298,13 @@ const getCommonStartString =(matches: string[]) => {
           autocapitalize="none"
           autocomplete="off"
           enterkeyhint="go"
-          v-model="data.vaunchInput"
+          v-model="sessionConfig.vaunchInput"
           @keydown.tab.prevent="complete"
           @keydown.enter.exact.prevent="sendCommand()"
           @keydown.enter.ctrl.exact.prevent="sendCommand(true)"
           @keydown.down.prevent="downKeyAction"
           @keydown.up.prevent="upKeyAction"
-          @keydown.esc.exact.prevent="data.vaunchInput = ''"
+          @keydown.esc.exact.prevent="sessionConfig.vaunchInput = ''"
           ref="inputBox"
         />
         <input

--- a/src/stores/sessionState.ts
+++ b/src/stores/sessionState.ts
@@ -8,6 +8,7 @@ export const useSessionStore = defineStore("session", {
       history: [] as string[],
       historyIndex: -1,
       showResponse: false,
+      vaunchInput: "",
     };
   },
 });

--- a/src/utilities/inputUtils.ts
+++ b/src/utilities/inputUtils.ts
@@ -1,0 +1,4 @@
+export function focusVaunchInput() {
+  let vaunchInput = document.getElementById("vaunch-input");
+  vaunchInput?.focus();
+}


### PR DESCRIPTION
Using the session config store for VaunchInput's value,
allows other components to easily modify it if needed
small utility function added to focus the vaunch inputbox