### PR TITLE
feat:right click handling will switch correctly

### DIFF
--- a/src/VaunchApp.vue
+++ b/src/VaunchApp.vue
@@ -196,12 +196,14 @@ const showFileOption = (file:VaunchUrlFile, xPos:number, yPos:number) => {
   data.optionFile = file;
   data.optionX = xPos;
   data.optionY = yPos;
+  if (sessionConfig.showFolderOptions) sessionConfig.showFolderOptions = false;
   sessionConfig.showFileOptions = true;
 }
 const showFolderOption = (folder:VaunchFolder, xPos:number, yPos:number) => {
   data.optionFolder = folder;
   data.optionX = xPos;
   data.optionY = yPos;
+  if (sessionConfig.showFileOptions) sessionConfig.showFileOptions = false;
   sessionConfig.showFolderOptions = true;
 }
 </script>

--- a/src/components/VaunchGuiFile.vue
+++ b/src/components/VaunchGuiFile.vue
@@ -20,9 +20,7 @@ const execute = (file: VaunchUrlFile, args: string[]) => {
 }
 
 const toggleOptions = (event:any) => {
-  if (!sessionConfig.showFolderOptions) {
-    emit('showFileOption', props.file, event.clientX, event.clientY)
-  }
+  emit('showFileOption', props.file, event.clientX, event.clientY)
 }
 </script>
 
@@ -63,7 +61,7 @@ const toggleOptions = (event:any) => {
     @click.exact="execute(file, [])"
     @click.ctrl="execute(file, ['_blank'])"
     @click.middle.exact="execute(file, ['_blank'])"
-    @click.right.prevent="toggleOptions($event)"
+    @click.right.prevent.stop="toggleOptions($event)"
     :id="props.file.parent.name + '-' + file.getIdSafeName()"
   >
     <div :class="{ fuzzyInfo: isFuzzy }">

--- a/src/components/VaunchGuiFolder.vue
+++ b/src/components/VaunchGuiFolder.vue
@@ -16,9 +16,7 @@ const passFileOption = (file: VaunchUrlFile, xPos:number, yPos:number) => {
 }
 
 const toggleOptions = (event:any) => {
-  if (!sessionConfig.showFileOptions) {
-    emit('showFolderOption', props.folder, event.clientX, event.clientY)
-  }
+  emit('showFolderOption', props.folder, event.clientX, event.clientY)
 }
 </script>
 
@@ -54,7 +52,7 @@ const toggleOptions = (event:any) => {
 </style>
 
 <template>
-  <div class="vaunch-folder vaunch-window" @click.right.prevent="toggleOptions($event)">
+  <div class="vaunch-folder vaunch-window" @click.right.prevent.stop="toggleOptions($event)">
     <span class="folder-title">
       <i :class="['fa-' + folder.iconClass, 'fa-' + folder.icon]"></i>
       <span v-if="config.titleCase">{{ folder.titleCase() }}</span>


### PR DESCRIPTION
right clicking in folder area, then right clicking on file will
switch to file context menu. uses .stop on @click to prevent
folder's handler also being called when right clicking on file