### PR TITLE
style:better mobile css

### DIFF
--- a/src/VaunchApp.vue
+++ b/src/VaunchApp.vue
@@ -246,7 +246,7 @@ main {
 }
 
 #option-buttons-container {
-  width: 100%;
+  width: 100vw;
 }
 
 .app-option-buttons {

--- a/src/assets/base.css
+++ b/src/assets/base.css
@@ -228,9 +228,17 @@ select {
 }
 
 @media (max-width: 768px) {
+  body, #app {
+    min-height: 100vh !important;
+    min-height: -webkit-fill-available !important;
+  }
   html {
+    height: -webkit-fill-available !important;
+  }
+  main {
     overflow-x: hidden;
   }
+
   #vaunch-folder-container {
     mask-image: unset;
   }
@@ -240,6 +248,7 @@ select {
     flex-direction: column;
     overflow-y: scroll;
     mask-image: linear-gradient(to bottom, transparent, black 3%, black 97%, transparent);
+    -webkit-mask-image: linear-gradient(to bottom, transparent, black 3%, black 97%, transparent);
   }
   #commands-container, .vaunch-command-folder {
     display: block;
@@ -254,7 +263,7 @@ select {
     top: 2.5vh !important;
     left: 2.5vw !important;
     width: 95vw !important;
-    height: 95vh !important;
+    height: 90vh !important;
   }
 
   .popup-window-small {

--- a/src/components/VaunchTooltip.vue
+++ b/src/components/VaunchTooltip.vue
@@ -51,6 +51,11 @@ onMounted(() => {
   padding: 0.5em;
   border: solid thin rgba(100, 100, 100, 0.1);
 }
+@media (max-width: 768px) { 
+  .vaunch-tippy {
+    display: none;
+  }
+}
 </style>
 
 // eslint-disable-next-line vue/valid-template-root


### PR DESCRIPTION
popup windows are slightly shorter, due to some mobile css fun,
where the viewport also includes the space taken up by the address bar
adding -webkit-fill-available is *meant* to fix this, but does not
look to have fixed it, so making windows shorter