### PR TITLE
fix:set certain gui commands to conver to lcase

### DIFF
--- a/src/components/VaunchAppEdit.vue
+++ b/src/components/VaunchAppEdit.vue
@@ -70,9 +70,9 @@ const saveApp = () => {
   let feh = new VaunchFeh();
   if (background.value.value != currentBg) feh.execute([background.value.value])
   // If an input is blank, leave it the same
-  let newWindowColor = windowColor.value.value  ? windowColor.value.value : '*';
-  let newTextColor = textColor.value.value ? textColor.value.value : '*';
-  let newHighlightColor = highlightColor.value.value ? highlightColor.value.value : '*';
+  let newWindowColor = windowColor.value.value ? (windowColor.value.value as string).toLowerCase() : '*';
+  let newTextColor = textColor.value.value ? (textColor.value.value as string).toLowerCase() : '*';
+  let newHighlightColor = highlightColor.value.value ? (highlightColor.value.value as string).toLowerCase() : '*';
   let setColor = new VaunchSetColor();
   setColor.execute([newWindowColor, newTextColor, newHighlightColor]);
   closeWindow();

--- a/src/components/VaunchFileAdd.vue
+++ b/src/components/VaunchFileAdd.vue
@@ -73,7 +73,7 @@ const createFile = () => {
   // Edit the icon of the file
   if (newIcon.value.value != "" || newIconClass.value.value != "" ) {
     let setIcon = new VaunchSetIcon();
-    let response: VaunchResponse = setIcon.execute([filePath, newIcon.value.value, newIconClass.value.value])
+    let response: VaunchResponse = setIcon.execute([filePath, newIcon.value.value.toLowerCase(), newIconClass.value.value.toLowerCase()])
     if (response.type == ResponseType.Error) return handleResponse(response);
   }
 

--- a/src/components/VaunchFileEdit.vue
+++ b/src/components/VaunchFileEdit.vue
@@ -54,7 +54,7 @@ const saveFile = () => {
   // Edit the icon of the file
   if (newIcon.value.value != props.file.icon || newIconClass.value.value != props.file.iconClass) {
     let setIcon = new VaunchSetIcon();
-    let response: VaunchResponse = setIcon.execute([originalPath, newIcon.value.value, newIconClass.value.value])
+    let response: VaunchResponse = setIcon.execute([originalPath, newIcon.value.value.toLowerCase(), newIconClass.value.value.toLowerCase()])
     if (response.type == ResponseType.Error) return handleResponse(response);
   }
 

--- a/src/components/VaunchFolderEdit.vue
+++ b/src/components/VaunchFolderEdit.vue
@@ -47,7 +47,7 @@ const saveFolder = () => {
   // Edit the icon of the folder
   if (newIcon.value.value != props.folder.icon || newIconClass.value.value != props.folder.iconClass) {
     let setIcon = new VaunchSetIcon();
-    let response: VaunchResponse = setIcon.execute([folderPath, newIcon.value.value, newIconClass.value.value])
+    let response: VaunchResponse = setIcon.execute([folderPath, newIcon.value.value.toLowerCase(), newIconClass.value.value.toLowerCase()])
     if (response.type == ResponseType.Error) return handleResponse(response);
   }
 


### PR DESCRIPTION
things like color names, and icon names, as they need to be
lower case to actually work. all other arguments aren't affeceted,
so upper case can be used still if wanted