### PR TITLE
fix:right click app context menu with no folders

### DIFF
--- a/src/VaunchApp.vue
+++ b/src/VaunchApp.vue
@@ -331,7 +331,7 @@ main {
         </div>
 
         <div
-          v-if="folders.items.length > 0 && config.showGUI"
+          v-if="config.showGUI"
           id="vaunch-folder-container"
           @click.right.prevent.self="showAppOption($event.clientX, $event.clientY)"
         >


### PR DESCRIPTION
Removed the if condition on folder length. Makes no difference the
div being there, other than right click to get Vaunch's context
menu actually works without it