### PR TITLE
fix:mkdir response use 'exists' correctly

### DIFF
--- a/src/models/commands/fs/VaunchMkdir.ts
+++ b/src/models/commands/fs/VaunchMkdir.ts
@@ -41,7 +41,7 @@ export class VaunchMkdir extends VaunchCommand {
       let plural = existingFolders.length > 1;
       return this.makeResponse(
         ResponseType.Info,
-        `The folder${plural ? 's':''} ${existingFolders.join(", ")} already exist and ${plural ? 'were' : 'was'} not made.`
+        `The folder${plural ? 's':''} ${existingFolders.join(", ")} already exist${plural ? '' : 's'} and ${plural ? 'were' : 'was'} not made.`
       );
     }
     return this.makeResponse(


### PR DESCRIPTION
Response contains 'exists' when only one folder already exists,
and use 'exist' when multiple passed folders already exist