### PR TITLE
fix:center background image

### DIFF
--- a/src/VaunchApp.vue
+++ b/src/VaunchApp.vue
@@ -309,6 +309,10 @@ main {
   cursor: pointer;
 }
 
+#main-container {
+  background-position: center;
+}
+
 /* Scrollbar theming */
 ::-webkit-scrollbar {
   width: 3px;


### PR DESCRIPTION
background image is now center aligned verically. Rather than the image being top aligned, with the bottom of the image cut off. Should make 'perfectally' sized images that match the user's desktop also line up the same