### PR TITLE
feat:rework folder store. prevent mv reordering

### DIFF
--- a/src/VaunchApp.vue
+++ b/src/VaunchApp.vue
@@ -47,11 +47,12 @@ const data = reactive({
 
 const folderList = computed<VaunchFolder[]>({
   get():VaunchFolder[] {
-    return folders.items
+    console.log(folders.rawFolders);
+    return folders.rawFolders;
   },
   set(value) {
+    console.log(value);
     folders.setFolders(value);
-    console.log(value)
   }
 })
 
@@ -381,7 +382,6 @@ main {
         </div>
 
         <draggable
-          v-if="config.showGUI"
           id="vaunch-folder-container"
           @click.right.prevent.self="
             showAppOption($event.clientX, $event.clientY)

--- a/src/components/VaunchGuiFolder.vue
+++ b/src/components/VaunchGuiFolder.vue
@@ -93,7 +93,7 @@ const deleteFolder = () =>
         <i class="fa-solid fa-trash" @click="deleteFolder" />
       </div>
     </span>
-    <draggable v-model="files" class="file-container" item-key="position">
+    <draggable v-model="files" class="file-container">
       <template #item="{element}">
         <VaunchGuiFile
           v-on:show-file-option="passFileOption"

--- a/src/models/VaunchFile.ts
+++ b/src/models/VaunchFile.ts
@@ -11,14 +11,12 @@ export abstract class VaunchFile {
   extension = "";
   description = "";
   filetype = "VaunchFile";
-  position: number;
 
   constructor(
     name: string,
     icon = "file",
     iconClass = "solid",
     hits = 0,
-    position = -1
   ) {
     this.fileName = name;
     this.aliases = [];
@@ -26,7 +24,6 @@ export abstract class VaunchFile {
     this.icon = icon;
     this.iconClass = iconClass;
     this.hits = hits;
-    this.position = position;
   }
 
   titleCase(): string {

--- a/src/models/VaunchFolder.ts
+++ b/src/models/VaunchFolder.ts
@@ -1,33 +1,26 @@
-import type { VaunchFile } from "./VaunchFile";
+import { VaunchFile } from "./VaunchFile";
 import { VaunchLink } from "./VaunchLink";
 import { VaunchQuery } from "./VaunchQuery";
-import { VaunchUrlFile } from "./VaunchUrlFile";
 
 export class VaunchFolder {
   name: string;
   files: VaunchFile[];
   icon: string;
   iconClass: string;
-  position: number;
 
   constructor(
     name: string,
     icon = "folder",
     iconClass = "solid",
-    position = -1
   ) {
     this.name = name;
     this.files = [];
     this.icon = icon;
     this.iconClass = iconClass;
-    this.position = position;
   }
 
   public addFile(newFile: VaunchFile): boolean {
     if (this.getFile(newFile.fileName)) return false;
-    // Set the new file's position to last
-    const nextPos: number = this.getFiles().length + 1;
-    newFile.position = nextPos;
     this.files.push(newFile);
     return true;
   }
@@ -47,9 +40,9 @@ export class VaunchFolder {
       .join(" ");
   }
 
-  getFile(fileName: string): VaunchUrlFile | undefined {
-    const file = this.files.find((file) => {file.fileName == fileName});
-    if (file instanceof VaunchUrlFile) {
+  getFile(fileName: string): VaunchFile | undefined {
+    const file = this.files.find(file => file.fileName == fileName);
+    if (file instanceof VaunchFile) {
       return file;
     }
     return undefined;
@@ -105,7 +98,6 @@ export class VaunchFolder {
       icon: this.icon,
       iconClass: this.iconClass,
       files: fileInfo,
-      position: this.position,
     };
     return data;
   }
@@ -117,7 +109,6 @@ export class VaunchFolder {
       data.name,
       data.icon,
       data.iconClass,
-      data.position
     );
     for (const fileData of data.files) {
       let file: VaunchFile | undefined = undefined;
@@ -129,8 +120,7 @@ export class VaunchFolder {
           fileData.icon,
           fileData.iconClass,
           fileData.hits,
-          fileData.description,
-          fileData.position
+          fileData.description
         );
       } else if (fileData.type == "VaunchQuery") {
         file = new VaunchQuery(
@@ -141,8 +131,7 @@ export class VaunchFolder {
           fileData.icon,
           fileData.iconClass,
           fileData.hits,
-          fileData.description,
-          fileData.position
+          fileData.description
         );
       }
       if (file != undefined) folder.addFile(file);

--- a/src/models/VaunchLink.ts
+++ b/src/models/VaunchLink.ts
@@ -13,13 +13,12 @@ export class VaunchLink extends VaunchUrlFile {
     icon = "file",
     iconClass = "solid",
     hits = 0,
-    description = "",
-    position = -1
+    description = ""
   ) {
     if (!name.endsWith(".lnk")) {
       name = name + ".lnk";
     }
-    super(name, parent, icon, iconClass, hits, description, position);
+    super(name, parent, icon, iconClass, hits, description);
     this.content = content;
   }
 
@@ -63,8 +62,7 @@ export class VaunchLink extends VaunchUrlFile {
       iconClass: this.iconClass,
       type: this.filetype,
       hits: this.hits,
-      description: this.description,
-      position: this.position,
+      description: this.description
     };
   }
 

--- a/src/models/VaunchQuery.ts
+++ b/src/models/VaunchQuery.ts
@@ -15,13 +15,12 @@ export class VaunchQuery extends VaunchUrlFile {
     icon = "magnifying-glass",
     iconClass = "solid",
     hits = 0,
-    description = "",
-    position = -1
+    description = ""
   ) {
     if (!name.endsWith(".qry")) {
       name = name + ".qry";
     }
-    super(name, parent, icon, iconClass, hits, description, position);
+    super(name, parent, icon, iconClass, hits, description);
     this.prefix = prefix.replace(":", "");
     this.content = content;
   }
@@ -92,8 +91,7 @@ export class VaunchQuery extends VaunchUrlFile {
       iconClass: this.iconClass,
       type: this.filetype,
       hits: this.hits,
-      description: this.description,
-      position: this.position,
+      description: this.description
     };
   }
 

--- a/src/models/VaunchUrlFile.ts
+++ b/src/models/VaunchUrlFile.ts
@@ -11,10 +11,9 @@ export abstract class VaunchUrlFile extends VaunchFile {
     icon: string,
     iconClass: string,
     hits = 0,
-    description = "",
-    position = -1
+    description = ""
   ) {
-    super(name, icon, iconClass, hits, position);
+    super(name, icon, iconClass, hits);
     this.description = description;
     if (parent) {
       this.parent = parent;

--- a/src/models/commands/config/VaunchImport.ts
+++ b/src/models/commands/config/VaunchImport.ts
@@ -111,8 +111,6 @@ export class VaunchImport extends VaunchCommand {
           // Only import files/folders if importConfig is true
           if (importFolders) {
             for (const folder of (importData as any).folders) {
-              // Set position to -1 to send all imported folders to the end if not overwriting
-              if (!overwrite) folder["position"] = -1;
               const folderToImport: VaunchFolder = VaunchFolder.parse(folder);
               // If this folder doesn't exist, import it. If overwriting, all folders will be gone by now
               if (!folders.getFolderByName(folderToImport.name)) {
@@ -122,8 +120,6 @@ export class VaunchImport extends VaunchCommand {
                 // If the folder already exists, try and merge files into it
                 importedComponents.push(`${folderToImport.name} (merged)`);
                 for (const fileToImport of folderToImport.getFiles()) {
-                  // Set position to -1 to send all imported files to the end if not overwriting
-                  if (!overwrite) fileToImport["position"] = -1;
                   const existingFolder: VaunchFolder = folders.getFolderByName(
                     folderToImport.name
                   );


### PR DESCRIPTION
Turns out vue draggable works in ways I don't understand.

It does not in fact update the `position` property when it is set as item-key, and even without the `position` property in files and folders it still somehow knows how to order things. Very confusing.

Using a Map<string, VaunchFolder> for the folder store was messing up how vuedraggable did ordering, so reworked the entire thing to use a simple Array<VaunchFolder> instead. Slightly less efficient when getting items, but makes things slightly easier to work with, and allows us to just update the folder name when performing `mv` as we don't need to worry about updating the key in a Map.

Thankfully everything was using calls from the folder store itself so just updating the store methods to work with the array was all that was really needed.

No changes to the serialised data was made, so no breaking changes in that area, thankfully