### PR TITLE
Drag files to folders

### DIFF
--- a/src/VaunchApp.vue
+++ b/src/VaunchApp.vue
@@ -37,6 +37,7 @@ let optionFile: VaunchFile = reactive(new VaunchLink("default", "default"));
 let optionFolder: VaunchFolder = reactive(new VaunchFolder("default"));
 const data = reactive({
   optionFile,
+  optionFileFolder: "",
   optionFolder,
   action: "",
   optionX: 0,
@@ -216,6 +217,7 @@ const setInputIcon = (file: VaunchFile | undefined) => {
 // this should be able to be re-written to use an exported function, similar to handleResponse()
 const showFileOption = (
   file: VaunchUrlFile,
+  folderName: string,
   xPos: number,
   yPos: number,
   action: string | null = null
@@ -223,6 +225,7 @@ const showFileOption = (
   // Opens a file's context menu. Sets the target file to display options for, and set the position
   // on screen for the component
   data.optionFile = file;
+  data.optionFileFolder = folderName;
   data.optionX = xPos;
   data.optionY = yPos;
   if (action) sessionConfig.action = action;
@@ -425,6 +428,7 @@ main {
     <VaunchFileOption
       v-if="sessionConfig.showFileOptions"
       :file="data.optionFile"
+      :folder-name="data.optionFileFolder"
       :x-pos="data.optionX"
       :y-pos="data.optionY"
     />

--- a/src/VaunchApp.vue
+++ b/src/VaunchApp.vue
@@ -72,7 +72,7 @@ const executeCommand = (commandArgs: string[], newTab = false) => {
   if (fuzzyFiles.items.length > 0 && config.fuzzy) {
     // Also shift this entry off the history, in case it was a qry file
     sessionConfig.history.shift();
-    let response = fuzzyFiles.items[fuzzyFiles.index].execute(commandArgs);
+    let response = fuzzyFiles.items[fuzzyFiles.index].file.execute(commandArgs);
     return handleResponse(response);
   }
 
@@ -154,17 +154,17 @@ const fuzzy = (input: string) => {
   if (input.length > 0) {
     // If fuzzy is enabled, search for files matching
     const folders = useFolderStore();
-    let matches: VaunchFile[] = folders.findFiles(input);
+    let matches = folders.findFiles(input);
     fuzzyFiles.setFuzzy(sortByHits(matches));
-    if (config.fuzzy) setInputIcon(matches[0]);
+    if (config.fuzzy) setInputIcon(matches[0].file);
   } else {
     fuzzyFiles.clear();
   }
   fuzzyFiles.index = 0;
 };
 
-const sortByHits = (files: VaunchFile[]) => {
-  return files.sort((a, b) => (a.hits < b.hits ? 1 : -1));
+const sortByHits = (files: Array<{'file':VaunchFile, 'folder':string}>) => {
+  return files.sort((a, b) => (a.file.hits < b.file.hits ? 1 : -1));
 };
 
 const updateFuzzyIndex = (increment: boolean) => {
@@ -184,7 +184,7 @@ const updateFuzzyIndex = (increment: boolean) => {
   // After updating the fuzzy index, set the input prompt icon to the selected file's icon
   // Otherwise, set it to the default
   if (fuzzyFiles.items[fuzzyFiles.index]) {
-    setInputIcon(fuzzyFiles.items[fuzzyFiles.index]);
+    setInputIcon(fuzzyFiles.items[fuzzyFiles.index].file);
   } else {
     setInputIcon(undefined);
   }

--- a/src/VaunchApp.vue
+++ b/src/VaunchApp.vue
@@ -395,13 +395,14 @@ main {
             delay="200"
             :delayOnTouchOnly="true"
             v-bind="dragOptions"
+            item-key="name"
           >
-          <template #item="{element}">
+          <template #item="{element: folder}">
             <VaunchGuiFolder
-              :key="element.name"
+              :key="folder.name"
               v-on:show-file-option="showFileOption"
               v-on:show-folder-option="showFolderOption"
-              :folder="element"
+              :folder="folder"
             />
           </template>
           </draggable>

--- a/src/components/VaunchFileEdit.vue
+++ b/src/components/VaunchFileEdit.vue
@@ -37,7 +37,7 @@ const saveFile = () => {
   // .value.value is used here to get the .value of the reference,
   // a HTMLInputElement, which itself has a .value property
 
-  let originalPath = props.file.getFilePath();
+  let originalPath = `${props.folderName}/${props.file.fileName}`;
 
   // Edit the content of the file, if prefix is present, it is a query file
   // and should be the firs arg after the filename

--- a/src/components/VaunchFileEdit.vue
+++ b/src/components/VaunchFileEdit.vue
@@ -10,10 +10,13 @@ import { VaunchSetDescription } from "@/models/commands/fs/VaunchSetDescription"
 import { useConfigStore } from "@/stores/config";
 import { handleResponse } from "@/utilities/response";
 import { VaunchSetPosition } from "@/models/commands/fs/VaunchSetPosition";
+import { useFolderStore } from "@/stores/folder";
+import type { VaunchFolder } from "@/models/VaunchFolder";
 const props = defineProps(["file", "folderName"]);
 
 const emit = defineEmits(["closeEdit"]);
 const config = useConfigStore();
+const folders = useFolderStore()
 
 const newName = ref();
 const newFolder = ref();
@@ -81,7 +84,8 @@ const saveFile = () => {
 
   // If a position has been set, update the position of the file
   // Adding one to get "human" position rather than positional index
-  if (newPos.value.value != props.file.findPosition() + 1) {
+  const parentFolder:VaunchFolder = folders.getFolderByName(props.folderName)
+  if (newPos.value.value != parentFolder.findFilePosition(props.file.fileName) + 1) {
     const setPos = new VaunchSetPosition();
     let response = setPos.execute([originalPath, newPos.value.value])
     if (response.type == ResponseType.Error) return handleResponse(response);
@@ -298,7 +302,7 @@ const saveFile = () => {
                   class="edit-input"
                   type="text"
                   id="new-position"
-                  :value="file.findPosition() + 1"
+                  :value="folders.getFolderByName(props.folderName).findFilePosition(props.file.fileName) + 1"
                 />
               </div>
             </div>

--- a/src/components/VaunchFileEdit.vue
+++ b/src/components/VaunchFileEdit.vue
@@ -10,7 +10,7 @@ import { VaunchSetDescription } from "@/models/commands/fs/VaunchSetDescription"
 import { useConfigStore } from "@/stores/config";
 import { handleResponse } from "@/utilities/response";
 import { VaunchSetPosition } from "@/models/commands/fs/VaunchSetPosition";
-const props = defineProps(["file"]);
+const props = defineProps(["file", "folderName"]);
 
 const emit = defineEmits(["closeEdit"]);
 const config = useConfigStore();
@@ -93,7 +93,7 @@ const saveFile = () => {
     .toLowerCase()
     .replace(/\s+/g, "_");
   if (
-    newFolderName != props.file.parent.name ||
+    newFolderName != props.folderName ||
     newName.value.value != props.file.fileName
   ) {
     // Ensure that the file ends with .<extension> and is in good filename format
@@ -234,7 +234,7 @@ const saveFile = () => {
                   class="edit-input"
                   type="text"
                   :id="file.getIdSafeName() + '-filename'"
-                  :value="file.parent.name"
+                  :value="props.folderName"
                 />
               </div>
             </div>

--- a/src/components/VaunchFileOption.vue
+++ b/src/components/VaunchFileOption.vue
@@ -26,7 +26,7 @@ onMounted(() => {
 
 const deleteFile = () => {
   let rm = new VaunchRm();
-  let filePath = `${props.file.getParentName()}/${props.file.fileName}`;
+  let filePath = `${props.folderName}/${props.file.fileName}`;
   rm.execute([filePath]);
   sessionConfig.showFileOptions = false;
 };

--- a/src/components/VaunchFileOption.vue
+++ b/src/components/VaunchFileOption.vue
@@ -8,7 +8,7 @@ import { useSessionStore } from "@/stores/sessionState";
 import { focusVaunchInput } from "@/utilities/inputUtils";
 import VaunchOption from "./VaunchOption.vue";
 
-const props = defineProps(["file", "xPos", "yPos"]);
+const props = defineProps(["file", "folderName", "xPos", "yPos"]);
 const optionContainer = ref();
 const sessionConfig = useSessionStore();
 
@@ -118,6 +118,7 @@ const setWindow = (window: string, show: boolean) => {
       <VaunchFileEdit
         v-if="state.showEdit"
         :file="file"
+        :folder-name="props.folderName"
         v-on:close-edit="setWindow('edit', false)"
       />
       <VaunchConfirm

--- a/src/components/VaunchFuzzy.vue
+++ b/src/components/VaunchFuzzy.vue
@@ -1,12 +1,13 @@
 <script setup lang="ts">
 import { useConfigStore } from "@/stores/config";
-import { useSessionStore } from "@/stores/sessionState";
+import { useFolderStore } from "@/stores/folder";
 import { ref, watch } from "vue";
 import VaunchGuiFile from "./VaunchGuiFile.vue";
 
 const props = defineProps(["fuzzyMatches", "currentIndex"]);
 const config = useConfigStore();
 const files = ref();
+const folders = useFolderStore()
 
 const getCurrentIndex = () => props.currentIndex;
 
@@ -84,11 +85,11 @@ watch(getCurrentIndex, (newIndex: number) => {
     <div class="file-container" id="fuzzy-file-container">
       <VaunchGuiFile
         ref="files"
-        :class="{ highlight: file === fuzzyMatches[currentIndex] }"
-        v-for="file in fuzzyMatches"
-        :key="file.fileName"
-        :file="file"
-        :parent-folder-name="'fuzzy'"
+        :class="{ highlight: fuzzyEntry === fuzzyMatches[currentIndex] }"
+        v-for="fuzzyEntry in fuzzyMatches"
+        :key="fuzzyEntry.file.fileName"
+        :file="fuzzyEntry.file"
+        :parent-folder-name="folders.getFolderByName(fuzzyEntry.folder).titleCase()"
         :is-fuzzy="true"
       />
     </div>

--- a/src/components/VaunchGuiFile.vue
+++ b/src/components/VaunchGuiFile.vue
@@ -8,7 +8,7 @@ import { focusVaunchInput } from "@/utilities/inputUtils";
 
 const config = useConfigStore();
 const sessionConfig = useSessionStore();
-const props = defineProps(["file", "isFuzzy"]);
+const props = defineProps(["file", "isFuzzy", "parentFolderName"]);
 const emit = defineEmits(["showFileOption"]);
 
 const execute = (file: VaunchUrlFile, args: string[]) => {
@@ -78,7 +78,7 @@ const deleteFile = () => emit("showFileOption", props.file, 0, 0, "delete");
     <div :class="{ fuzzyInfo: isFuzzy, fileMain: true }">
       <i :class="['fa-' + file.iconClass, 'fa-' + file.icon, 'file-icon']"></i>
       <span v-if="isFuzzy" class="filename"
-        >{{ file.getParentName(config.titleCase) }}:
+        >{{ props.parentFolderName }}:
       </span>
       <span v-if="config.titleCase" :class="{ filename: !isFuzzy }">
         {{ file.titleCase() }}

--- a/src/components/VaunchGuiFolder.vue
+++ b/src/components/VaunchGuiFolder.vue
@@ -27,7 +27,7 @@ const passFileOption = (
   yPos: number,
   action: null | string = null
 ) => {
-  emit("showFileOption", file, xPos, yPos, action);
+  emit("showFileOption", file, props.folder.name, xPos, yPos, action);
 };
 
 const toggleOptions = (event: any) => {
@@ -102,6 +102,7 @@ const deleteFolder = () =>
         delay="200"
         :delayOnTouchOnly="true"
         v-bind="dragOptions"
+        group="vaunch-folder"
       >
       <template #item="{element}">
         <VaunchGuiFile

--- a/src/components/VaunchGuiFolder.vue
+++ b/src/components/VaunchGuiFolder.vue
@@ -103,12 +103,13 @@ const deleteFolder = () =>
         :delayOnTouchOnly="true"
         v-bind="dragOptions"
         group="vaunch-folder"
+        :item-key="folder.name"
       >
-      <template #item="{element}">
+      <template #item="{element: file}">
         <VaunchGuiFile
         v-on:show-file-option="passFileOption"
-        :file="element"
-        :key="element.fileName"
+        :file="file"
+        :key="file.fileName"
         :parent-folder-name="folder.name"
         />
       </template>

--- a/src/models/VaunchUrlFile.ts
+++ b/src/models/VaunchUrlFile.ts
@@ -63,8 +63,4 @@ export abstract class VaunchUrlFile extends VaunchFile {
     if (linkUrl) return true;
     return false;
   }
-
-  getFilePath(): string {
-    return `${this.parent?.name}/${this.fileName}`;
-  }
 }

--- a/src/models/VaunchUrlFile.ts
+++ b/src/models/VaunchUrlFile.ts
@@ -47,16 +47,6 @@ export abstract class VaunchUrlFile extends VaunchFile {
     }
   }
 
-  protected getParentName(titleCase = false): string {
-    // Returns the parent folder for this file
-    if (this.parent) {
-      if (titleCase) {
-        return this.parent.titleCase();
-      }
-      return this.parent.name;
-    } else return "";
-  }
-
   getCorrectURL(): string {
     // Returns a url representation of this file's content
     const linkUrl: URL | undefined = this.createUrl();

--- a/src/models/VaunchUrlFile.ts
+++ b/src/models/VaunchUrlFile.ts
@@ -77,8 +77,4 @@ export abstract class VaunchUrlFile extends VaunchFile {
   getFilePath(): string {
     return `${this.parent?.name}/${this.fileName}`;
   }
-
-  findPosition():number {
-    return this.parent?.findFilePosition(this.fileName) || 0
-  }
 }

--- a/src/stores/folder.ts
+++ b/src/stores/folder.ts
@@ -91,9 +91,10 @@ export const useFolderStore: StoreDefinition = defineStore({
       this.rawFolders = new Array<VaunchFolder>();
     },
     findFiles(search: string, types: string[] = []) {
-      const matchingFiles: VaunchFile[] = [];
+      const matchingFiles: Array<{'file':VaunchFile, 'folder':string}> = new Array<{'file':VaunchFile, 'folder':string}>();
       for (const folder of this.rawFolders.values()) {
-        matchingFiles.push(...folder.searchFile(search, types));
+        const matches = folder.searchFile(search, types)
+        matches.forEach(match => matchingFiles.push({'file':match, 'folder': folder.name}))
       }
       return matchingFiles;
     },

--- a/src/stores/fuzzy.ts
+++ b/src/stores/fuzzy.ts
@@ -5,13 +5,13 @@ export const useFuzzyStore = defineStore("fuzzy", {
   // Store to hold currently matched files from the fuzzy finder
   state: () => {
     return {
-      items: [] as VaunchFile[],
+      items: [] as Array<{'file':VaunchFile, 'folder':string}>,
       index: 0,
     };
   },
   actions: {
     // Sets the list of found files
-    setFuzzy(files: VaunchFile[]) {
+    setFuzzy(files: Array<{'file':VaunchFile, 'folder':string}>) {
       this.items = files;
     },
     // Clears the list of found files


### PR DESCRIPTION
Allows dragging files between folders, essentially acting as a more interactive `mv` command.

Essentially this just moves the file out of one folder's array and into anothers.
Technically, this needed a fair bit of work (read: gutting stuff out) and re-work (read: passing folder names around the UI a silly amount) so handle this new way of moving files as, moving a file between arrays did not give me any of the old luxaries of commands that could edit the files parent property for example, so anything that referenced this could be out of date if the file was dragged to a new folder

Edit UI had to be changed to get the current folder the file resides in from other UI elements that know the truth
Fuzy searching had to changed to get the current folder a file resides in rather than taking what the file *thinks* is its parent folder as gospel.

Overall, things work now, and it's pretty cool being able to drag and drop folders between things. Initially it felt way too easy by adding `group` to the `draggable` element, and then I ran into that entire can of worms above