### PR TITLE
feat:use fuse for true fuzzy searching

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@vitejs/plugin-vue": "^4.1.0",
         "@vueuse/core": "^8.5.0",
+        "fuse.js": "^6.6.2",
         "i": "^0.3.7",
         "npm": "^8.19.2",
         "npm-run-all": "^4.1.5",
@@ -2895,6 +2896,14 @@
       "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/fuse.js": {
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-6.6.2.tgz",
+      "integrity": "sha512-cJaJkxCCxC8qIIcPBF9yGxY0W/tVZS3uEISDxhYIdtk8OL93pe+6Zj7LjCqVV4dzbqcriOZ+kQ/NE4RXZHsIGA==",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/get-caller-file": {
@@ -10115,6 +10124,11 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
       "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ=="
+    },
+    "fuse.js": {
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-6.6.2.tgz",
+      "integrity": "sha512-cJaJkxCCxC8qIIcPBF9yGxY0W/tVZS3uEISDxhYIdtk8OL93pe+6Zj7LjCqVV4dzbqcriOZ+kQ/NE4RXZHsIGA=="
     },
     "get-caller-file": {
       "version": "2.0.5",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@vitejs/plugin-vue": "^4.1.0",
     "@vueuse/core": "^8.5.0",
+    "fuse.js": "^6.6.2",
     "i": "^0.3.7",
     "npm": "^8.19.2",
     "npm-run-all": "^4.1.5",

--- a/src/VaunchApp.vue
+++ b/src/VaunchApp.vue
@@ -156,7 +156,7 @@ const fuzzy = (input: string) => {
     // If fuzzy is enabled, search for files matching
     const folders = useFolderStore();
     let matches = folders.findFiles(input);
-    fuzzyFiles.setFuzzy(sortByHits(matches));
+    fuzzyFiles.setFuzzy(matches);
     if (config.fuzzy) {
       if (matches[0]) {
         setInputIcon(matches[0].file);
@@ -164,10 +164,6 @@ const fuzzy = (input: string) => {
     }
   }
   fuzzyFiles.index = 0;
-};
-
-const sortByHits = (files: Array<{'file':VaunchFile, 'folder':string}>) => {
-  return files.sort((a, b) => (a.file.hits < b.file.hits ? 1 : -1));
 };
 
 const updateFuzzyIndex = (increment: boolean) => {

--- a/src/models/VaunchFolder.ts
+++ b/src/models/VaunchFolder.ts
@@ -56,26 +56,6 @@ export class VaunchFolder {
     this.files = newFiles
   }
 
-  searchFile(search: string, types: string[] = []): VaunchFile[] {
-    const matches: VaunchFile[] = [];
-    for (const file of this.files) {
-      if (file.fileName.includes(search)) {
-        if (types.includes(file.filetype)) {
-          matches.push(file);
-        } else if (types.length == 0) {
-          matches.push(file);
-        }
-      } else if (file.namesStartWith(search)) {
-        if (types.includes(file.filetype)) {
-          matches.push(file);
-        } else if (types.length == 0) {
-          matches.push(file);
-        }
-      }
-    }
-    return matches;
-  }
-
   removeFile(toDelete: string):boolean {
     const fileToDelete = this.files.filter((file) => file.fileName == toDelete)
     if (fileToDelete.length > 0) {


### PR DESCRIPTION
Rather than a hald baked implementation with checking if words include things and sorting purely on hits, use fuse.js to do a true score based fuzzy search based on multiple file properties.

Unfortunately working in the hit system isn't exactly working right now, so leaving it out. Hits are still recorded so could be worked back into the scoring/sorting in future