### PR TITLE
chore: change Query desc wording

### DIFF
--- a/src/models/VaunchQuery.ts
+++ b/src/models/VaunchQuery.ts
@@ -27,7 +27,7 @@ export class VaunchQuery extends VaunchUrlFile {
 
   getDescription(): string {
     if (this.description) return `${this.prefix}: ${this.description}`;
-    return `Search: ${this.prefix}: ${this.content}`;
+    return `${this.prefix}: Search ${this.content}`;
   }
 
   getNames(): string[] {


### PR DESCRIPTION
change from "Search" > prefix > URL to prefix > "Search" > URL.

Reads slightly better and matches the ordering when the file has a set description, where it does prefix > description