### PR TITLE
fix:remove parents from files

### DIFF
--- a/src/models/VaunchFolder.ts
+++ b/src/models/VaunchFolder.ts
@@ -100,7 +100,6 @@ export class VaunchFolder {
         file = new VaunchLink(
           fileData.fileName,
           fileData.content,
-          folder,
           fileData.icon,
           fileData.iconClass,
           fileData.hits,
@@ -111,7 +110,6 @@ export class VaunchFolder {
           fileData.fileName,
           fileData.prefix,
           fileData.content,
-          folder,
           fileData.icon,
           fileData.iconClass,
           fileData.hits,

--- a/src/models/VaunchLink.ts
+++ b/src/models/VaunchLink.ts
@@ -1,4 +1,3 @@
-import type { VaunchFolder } from "./VaunchFolder";
 import { ResponseType, type VaunchResponse } from "./VaunchResponse";
 import { VaunchUrlFile } from "./VaunchUrlFile";
 
@@ -9,7 +8,6 @@ export class VaunchLink extends VaunchUrlFile {
   constructor(
     name: string,
     content: string,
-    parent: VaunchFolder | undefined = undefined,
     icon = "file",
     iconClass = "solid",
     hits = 0,
@@ -18,7 +16,7 @@ export class VaunchLink extends VaunchUrlFile {
     if (!name.endsWith(".lnk")) {
       name = name + ".lnk";
     }
-    super(name, parent, icon, iconClass, hits, description);
+    super(name, icon, iconClass, hits, description);
     this.content = content;
   }
 

--- a/src/models/VaunchQuery.ts
+++ b/src/models/VaunchQuery.ts
@@ -1,4 +1,3 @@
-import type { VaunchFolder } from "./VaunchFolder";
 import { ResponseType, type VaunchResponse } from "./VaunchResponse";
 import { VaunchUrlFile } from "./VaunchUrlFile";
 
@@ -11,7 +10,6 @@ export class VaunchQuery extends VaunchUrlFile {
     name: string,
     prefix: string,
     content: string,
-    parent: VaunchFolder,
     icon = "magnifying-glass",
     iconClass = "solid",
     hits = 0,
@@ -20,7 +18,7 @@ export class VaunchQuery extends VaunchUrlFile {
     if (!name.endsWith(".qry")) {
       name = name + ".qry";
     }
-    super(name, parent, icon, iconClass, hits, description);
+    super(name, icon, iconClass, hits, description);
     this.prefix = prefix.replace(":", "");
     this.content = content;
   }

--- a/src/models/VaunchUrlFile.ts
+++ b/src/models/VaunchUrlFile.ts
@@ -1,13 +1,10 @@
 import { VaunchFile } from "./VaunchFile";
-import type { VaunchFolder } from "./VaunchFolder";
 
 export abstract class VaunchUrlFile extends VaunchFile {
-  parent: VaunchFolder | undefined;
   filetype = "VaunchUrlFile";
 
   constructor(
     name: string,
-    parent: VaunchFolder | undefined,
     icon: string,
     iconClass: string,
     hits = 0,
@@ -15,10 +12,6 @@ export abstract class VaunchUrlFile extends VaunchFile {
   ) {
     super(name, icon, iconClass, hits);
     this.description = description;
-    if (parent) {
-      this.parent = parent;
-      this.aliases.push(`${this.parent.name}/${this.fileName}`);
-    }
   }
 
   protected prependHttps(urlString: string): string {

--- a/src/models/commands/fs/VaunchMv.ts
+++ b/src/models/commands/fs/VaunchMv.ts
@@ -120,7 +120,6 @@ export class VaunchMv extends VaunchCommand {
         file.setName(newFileName);
         folder.removeFile(fileToMove);
         newFolder.addFile(file);
-        file.parent = newFolder;
       } else {
         return this.makeResponse(
           ResponseType.Error,

--- a/src/tests/VaunchLink.spec.ts
+++ b/src/tests/VaunchLink.spec.ts
@@ -1,21 +1,17 @@
 import { test, describe, expect, beforeEach } from "vitest";
-import { VaunchFolder } from "../models/VaunchFolder";
 import { VaunchLink } from "../models/VaunchLink";
 import { ResponseType } from "../models/VaunchResponse";
 
-const parent = new VaunchFolder("test");
 let file: VaunchLink;
 
 beforeEach(() => {
   file = new VaunchLink(
     "test_file",
     "http://example.com",
-    parent,
     "vuejs",
     "brands",
     100,
-    "Test File",
-    1
+    "Test File"
   );
 });
 


### PR DESCRIPTION
No longer used within the UI, as it is passed by other components. Nothing in the models were actually using them, other than setting them during import/moving.

Removing doesn't look to break anything, and there were barely any references to them left before this