### PR TITLE
feat:GUI add file set default icon

### DIFF
--- a/src/components/VaunchFileAdd.vue
+++ b/src/components/VaunchFileAdd.vue
@@ -318,7 +318,7 @@ const createFile = () => {
                     class="edit-input"
                     type="text"
                     id="new-icon-name"
-                    value="file"
+                    :value="state.fileType == 'lnk' ? 'file' : 'magnifying-glass'"
                   />
                 </div>
               </div>


### PR DESCRIPTION
If changing between link and query files when adding a file update the file's icon between file and magnifying-glass respectively