### PR TITLE
fix:allow rclick for vaunch settings in upper half

### DIFF
--- a/src/VaunchApp.vue
+++ b/src/VaunchApp.vue
@@ -356,6 +356,9 @@ main {
   <main
     id="main-container"
     :style="{ 'background-image': 'url(' + config.background + ')' }"
+    @click.right.prevent="
+              showAppOption($event.clientX, $event.clientY)
+            "
   >
     <VaunchInput
       v-on:command="executeCommand"
@@ -387,9 +390,6 @@ main {
         <TransitionGroup>
           <draggable
             id="vaunch-folder-container"
-            @click.right.prevent.self="
-              showAppOption($event.clientX, $event.clientY)
-            "
             v-model="folderList"
             delay="200"
             :delayOnTouchOnly="true"

--- a/src/components/VaunchInput.vue
+++ b/src/components/VaunchInput.vue
@@ -304,7 +304,7 @@ const getCommonStartString = (matches: string[]) => {
           'fa-3x',
         ]"
       ></i>
-      <div id="input-wrapper">
+      <div id="input-wrapper" @click.right.prevent.stop>
         <input
           id="vaunch-input"
           type="text"


### PR DESCRIPTION
move right click trigger for app options to main and remove self restriction. Add right click stop on VaunchInput inner element to prevent right click inside the input box to show the app options context menu